### PR TITLE
Prompt metrics, open-ended grading metrics, and keyword RAG

### DIFF
--- a/app/core/exam_builder.py
+++ b/app/core/exam_builder.py
@@ -204,7 +204,8 @@ class QuestionFactory:
         difficulty: str = "medium",
         provider: Literal["openai", "yandex"] = "openai",
         model_name: Optional[str] = None,
-        language: str = "en"
+        language: str = "en",
+        prompt_variant: str = "default"
     ) -> Dict[str, Any]:
         """
         Generate a single question from content.
@@ -245,7 +246,8 @@ class QuestionFactory:
             content=content,
             question_type=question_type,
             difficulty=difficulty,
-            language=language
+            language=language,
+            prompt_variant=prompt_variant
         )
 
 

--- a/app/core/prompt_comparator.py
+++ b/app/core/prompt_comparator.py
@@ -1,0 +1,51 @@
+"""
+Prompt variant comparison utilities.
+"""
+from __future__ import annotations
+
+from typing import Dict, List, Any
+
+from app.core.evaluator import QuestionQualityEvaluator
+from app.core.generator import QuestionGenerator
+from app.core.validator import QuestionValidator
+from app.models.schemas import ExamConfig
+from app.core.parser import ParsedDocument
+
+
+class PromptComparator:
+    """Compare prompt variants using quality and grounding metrics."""
+
+    def __init__(
+        self,
+        generator: QuestionGenerator | None = None,
+        evaluator: QuestionQualityEvaluator | None = None,
+        validator: QuestionValidator | None = None,
+    ):
+        self.generator = generator or QuestionGenerator()
+        self.evaluator = evaluator or QuestionQualityEvaluator()
+        self.validator = validator or QuestionValidator()
+
+    def compare_variants(
+        self,
+        document: ParsedDocument,
+        config: ExamConfig,
+        variants: List[str],
+    ) -> Dict[str, Any]:
+        results: Dict[str, Any] = {"variants": {}}
+
+        for variant in variants:
+            variant_config = config.model_copy(update={"prompt_variant": variant})
+            exam = self.generator.generate(document, variant_config, f"prompt-{variant}")
+            quality = self.evaluator.evaluate_overall_quality(exam.questions)
+            grounding = self.validator.validate_exam(exam, document)
+
+            results["variants"][variant] = {
+                "quality": quality,
+                "grounding": {
+                    "grounded_ratio": grounding.grounded_ratio,
+                    "section_coverage": grounding.section_coverage,
+                    "issues": grounding.issues,
+                },
+            }
+
+        return results

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -120,6 +120,10 @@ class ExamConfig(BaseModel):
     seed: Optional[int] = Field(None, description="Random seed for reproducibility")
     provider: Literal["openai", "yandex", "local"] = Field("openai", description="LLM provider for generation/grading")
     model_name: Optional[str] = Field(None, description="Specific model to use for the provider")
+    prompt_variant: str = Field("default", description="Prompt template variant for generation")
+    rag_enabled: bool = Field(False, description="Enable retrieval-augmented generation")
+    rag_top_k: int = Field(3, ge=1, le=10, description="Top-k sections to retrieve when RAG is enabled")
+    rag_query: Optional[str] = Field(None, description="Optional query for RAG retrieval")
     model_config = ConfigDict(protected_namespaces=())
 
     @model_validator(mode='after')
@@ -234,6 +238,8 @@ class QuestionResult(BaseModel):
     given_text: Optional[str] = Field(None, description="Student's text answer (for open_ended)")
     partial_credit: float = Field(0.0, ge=0.0, le=1.0, description="Partial credit (0.0-1.0)")
     feedback: Optional[str] = Field(None, description="Detailed feedback (for open_ended)")
+    rubric_scores: Optional[List[int]] = Field(None, description="Rubric scores (for open_ended)")
+    metrics: Optional[Dict[str, float]] = Field(None, description="Open-ended grading metrics")
 
 
 class GradeSummary(BaseModel):

--- a/app/prompts/registry.py
+++ b/app/prompts/registry.py
@@ -1,0 +1,28 @@
+"""
+Prompt template registry for generation variants.
+"""
+from __future__ import annotations
+
+from app.prompts import prompts_en, prompts_ru
+
+
+_GROUNDING_HINTS = {
+    "en": "\n\nGrounding requirements:\n- Use exact terms from the provided content\n- Avoid introducing facts not present in the content\n- Keep the question tightly anchored to specific sentences\n",
+    "ru": "\n\nТребования к привязке:\n- Используйте точные термины из предоставленного контента\n- Не добавляйте факты, отсутствующие в контенте\n- Привязывайте вопрос к конкретным формулировкам\n",
+}
+
+
+def get_prompt_template(language: str, question_type: str, variant: str) -> str:
+    """
+    Return a prompt template for the given variant.
+    """
+    prompts_module = prompts_ru if language == "ru" else prompts_en
+    if question_type == "open_ended":
+        base = prompts_module.OPEN_ENDED_PROMPT_RU if language == "ru" else prompts_module.OPEN_ENDED_PROMPT_EN
+    else:
+        base = prompts_module.CHOICE_QUESTION_PROMPT_RU if language == "ru" else prompts_module.CHOICE_QUESTION_PROMPT_EN
+
+    if variant == "grounded":
+        return base + _GROUNDING_HINTS["ru" if language == "ru" else "en"]
+
+    return base

--- a/app/services/llm_provider.py
+++ b/app/services/llm_provider.py
@@ -22,7 +22,8 @@ class LLMProvider(Protocol):
         content: str,
         question_type: str,
         difficulty: str = "medium",
-        language: str = "en"
+        language: str = "en",
+        prompt_variant: Optional[str] = None
     ) -> Dict[str, Any]:
         ...
 
@@ -62,13 +63,15 @@ class LocalLLMClient:
         content: str,
         question_type: str,
         difficulty: str = "medium",
-        language: str = "en"
+        language: str = "en",
+        prompt_variant: Optional[str] = None
     ) -> Dict[str, Any]:
         # MD5 used for deterministic seed generation only, not cryptography
         seed = int(hashlib.md5(content.encode(), usedforsecurity=False).hexdigest(), 16) % 1000
         self._counter += 1
         keyword = content.split()[0] if content else "content"
-        stem = f"[{language.upper()}][{difficulty}] Based on {keyword} {seed}, what is the key fact? #{self._counter}"
+        variant_tag = f"[{prompt_variant}]" if prompt_variant else ""
+        stem = f"[{language.upper()}][{difficulty}]{variant_tag} Based on {keyword} {seed}, what is the key fact? #{self._counter}"
 
         if question_type == "open_ended":
             return {

--- a/app/services/yandex_client.py
+++ b/app/services/yandex_client.py
@@ -80,7 +80,8 @@ class YandexGPTClient:
         content: str,
         question_type: str,
         difficulty: str = "medium",
-        language: str = "en"
+        language: str = "en",
+        prompt_variant: str = "default"
     ) -> Dict[str, Any]:
         """
         Generate a single question from content.
@@ -94,7 +95,7 @@ class YandexGPTClient:
         Returns:
             Dict with question data (stem, options, correct, rubric) for all types
         """
-        prompt = self._build_generation_prompt(content, question_type, difficulty, language)
+        prompt = self._build_generation_prompt(content, question_type, difficulty, language, prompt_variant)
 
         # Get language-specific system message
         prompts_module = prompts_ru if language == "ru" else prompts_en
@@ -129,7 +130,8 @@ class YandexGPTClient:
         content: str,
         question_type: str,
         difficulty: str,
-        language: str
+        language: str,
+        prompt_variant: str
     ) -> str:
         """
         Build prompt for question generation.
@@ -143,11 +145,9 @@ class YandexGPTClient:
         Returns:
             Formatted prompt string
         """
-        # Select correct prompt module based on language
-        prompts_module = prompts_ru if language == "ru" else prompts_en
-
         if question_type == "open_ended":
-            template = prompts_module.OPEN_ENDED_PROMPT_RU if language == "ru" else prompts_module.OPEN_ENDED_PROMPT_EN
+            from app.prompts.registry import get_prompt_template
+            template = get_prompt_template(language, question_type, prompt_variant)
             return template.format(content=content, difficulty=difficulty)
 
         # Choice questions (single or multiple)
@@ -166,7 +166,8 @@ class YandexGPTClient:
                 type_instruction = "Create a multiple-choice question with 2-3 correct answers."
                 correct_format = "The 'correct' field must be a list with 2-3 indices (e.g., [1, 3])."
 
-        template = prompts_module.CHOICE_QUESTION_PROMPT_RU if language == "ru" else prompts_module.CHOICE_QUESTION_PROMPT_EN
+        from app.prompts.registry import get_prompt_template
+        template = get_prompt_template(language, question_type, prompt_variant)
         return template.format(
             content=content,
             difficulty=difficulty,

--- a/tests/unit/test_grader.py
+++ b/tests/unit/test_grader.py
@@ -331,6 +331,9 @@ class TestOpenEndedGrading:
         assert result.given_text is not None
         assert result.feedback is not None
         assert 0.0 <= result.partial_credit <= 1.0
+        assert result.rubric_scores is not None
+        assert result.metrics is not None
+        assert 0.0 <= result.metrics.get("rubric_coverage", 0.0) <= 1.0
 
     def test_grade_open_ended_uses_ai_scoring(self, grader, open_ended_exam):
         """Test that open-ended grading uses AI for scoring."""

--- a/tests/unit/test_prompt_comparator.py
+++ b/tests/unit/test_prompt_comparator.py
@@ -1,0 +1,48 @@
+from app.core.parser import ParsedDocument, ParsedSection
+from app.core.prompt_comparator import PromptComparator
+from app.models.schemas import ExamConfig
+
+
+def test_prompt_comparator_returns_report():
+    document = ParsedDocument(
+        title="Doc",
+        sections=[
+            ParsedSection(
+                heading="Alpha",
+                content="Alpha content about hypertension and diagnosis.",
+                level=2,
+                start_pos=0,
+                end_pos=50,
+            ),
+            ParsedSection(
+                heading="Beta",
+                content="Beta content about treatment and management.",
+                level=2,
+                start_pos=51,
+                end_pos=120,
+            ),
+        ],
+        source_text="Alpha content about hypertension and diagnosis. "
+                    "Beta content about treatment and management.",
+    )
+
+    comparator = PromptComparator()
+    config = ExamConfig(
+        total_questions=4,
+        single_choice_ratio=0.5,
+        multiple_choice_ratio=0.5,
+        open_ended_ratio=0.0,
+        provider="local",
+    )
+
+    report = comparator.compare_variants(
+        document=document,
+        config=config,
+        variants=["default", "grounded"],
+    )
+
+    assert "variants" in report
+    assert set(report["variants"].keys()) == {"default", "grounded"}
+    for variant_report in report["variants"].values():
+        assert "quality" in variant_report
+        assert "grounding" in variant_report

--- a/tests/unit/test_prompt_registry.py
+++ b/tests/unit/test_prompt_registry.py
@@ -1,0 +1,22 @@
+import pytest
+
+from app.prompts import prompts_en
+from app.prompts.registry import get_prompt_template
+
+
+def test_default_variant_returns_base_template():
+    template = get_prompt_template(
+        language="en",
+        question_type="single_choice",
+        variant="default",
+    )
+    assert prompts_en.CHOICE_QUESTION_PROMPT_EN.strip() in template
+
+
+def test_grounded_variant_adds_grounding_instruction():
+    template = get_prompt_template(
+        language="en",
+        question_type="open_ended",
+        variant="grounded",
+    )
+    assert "Grounding" in template or "grounded" in template.lower()

--- a/tests/unit/test_retriever.py
+++ b/tests/unit/test_retriever.py
@@ -1,0 +1,36 @@
+from app.core.parser import ParsedDocument, ParsedSection
+from app.core.retriever import RAGRetriever
+
+
+def test_retriever_selects_relevant_sections_by_query():
+    document = ParsedDocument(
+        title="Doc",
+        sections=[
+            ParsedSection(
+                heading="Heart",
+                content="Hypertension and blood pressure management.",
+                level=2,
+                start_pos=0,
+                end_pos=50,
+            ),
+            ParsedSection(
+                heading="Lungs",
+                content="Asthma and pulmonary function treatment.",
+                level=2,
+                start_pos=51,
+                end_pos=100,
+            ),
+        ],
+        source_text="Hypertension and blood pressure management. "
+                    "Asthma and pulmonary function treatment.",
+    )
+
+    retriever = RAGRetriever()
+    results = retriever.retrieve_relevant_sections(
+        document=document,
+        query="blood pressure hypertension",
+        top_k=1,
+    )
+
+    assert len(results) == 1
+    assert results[0].heading == "Heart"


### PR DESCRIPTION
## Summary\n- Add prompt template registry and prompt variant comparison\n- Enrich open-ended grading results with rubric/coverage metrics\n- Add keyword-based RAG retrieval and config toggles\n\n## Testing\n- pytest -v\n- behave tests/bdd/features\n\nFixes #21\nFixes #22\nFixes #23\n